### PR TITLE
Agent

### DIFF
--- a/librina/include/librina/common.h
+++ b/librina/include/librina/common.h
@@ -104,6 +104,9 @@ public:
 	std::string entityInstance;
 };
 
+ApplicationProcessNamingInformation
+decode_apnameinfo(const std::string &encodedString);
+
 /**
  * This class defines the characteristics of a flow
  */

--- a/librina/src/common.cc
+++ b/librina/src/common.cc
@@ -191,14 +191,16 @@ decode_apnameinfo(const std::string &encodedString)
                 elems.push_back(elem);
         }
 
-        if (elems.size() != 4) {
+        if (elems.size() < 3) {
                 return ret;
         }
 
         ret.processName = elems[0];
         ret.processInstance = elems[1];
         ret.entityName = elems[2];
-        ret.entityInstance = elems[3];
+        if (elems.size() >= 4) {
+                ret.entityInstance = elems[3];
+        }
 
         return ret;
 }

--- a/librina/src/common.cc
+++ b/librina/src/common.cc
@@ -179,6 +179,30 @@ const std::string ApplicationProcessNamingInformation::toString() const{
         return ss.str();
 }
 
+ApplicationProcessNamingInformation
+decode_apnameinfo(const std::string &encodedString)
+{
+        ApplicationProcessNamingInformation ret;
+        std::stringstream ss(encodedString);
+        std::string elem;
+        std::vector<std::string> elems;
+
+        while (std::getline(ss, elem, '-')) {
+                elems.push_back(elem);
+        }
+
+        if (elems.size() != 4) {
+                return ret;
+        }
+
+        ret.processName = elems[0];
+        ret.processInstance = elems[1];
+        ret.entityName = elems[2];
+        ret.entityInstance = elems[3];
+
+        return ret;
+}
+
 /* CLASS FLOW SPECIFICATION */
 
 FlowSpecification::FlowSpecification() {

--- a/rinad/src/common/debug.h
+++ b/rinad/src/common/debug.h
@@ -2,6 +2,7 @@
  * Debugging utils
  *
  *    Francesco Salvestrini <f.salvestrini@nextworks.it>
+ *    Vincenzo Maffione     <v.maffione@nextworks.it>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,6 +22,17 @@
 #ifndef RINAD_DEBUG_H
 #define RINAD_DEBUG_H
 
+#include <string>
+
 void dump_backtrace(void);
+
+#ifndef FLUSH_LOG
+	//Force log flushing
+	#define FLUSH_LOG(_lev_, _ss_)\
+			do{\
+				LOGF_##_lev_ ("%s", (_ss_).str().c_str());\
+				ss.str(std::string());\
+			}while (0)
+#endif //FLUSH_LOG
 
 #endif

--- a/rinad/src/common/rina-configuration.h
+++ b/rinad/src/common/rina-configuration.h
@@ -223,6 +223,12 @@ class RINAConfiguration {
                 rina::ApplicationProcessNamingInformation>
                 applicationToDIFMappings;
 
+	/*
+	 * The path of the configuration file where the configuration
+	 * comes from
+	 */
+	std::string configuration_file;
+
         bool lookup_dif_properties(
                         const rina::ApplicationProcessNamingInformation& dif_name,
                         DIFProperties& result) const;

--- a/rinad/src/ipcm/addon.cc
+++ b/rinad/src/ipcm/addon.cc
@@ -37,8 +37,7 @@ rina::Lockable Addon::mutex;
 std::list<Addon*> Addon::event_subscribers;
 
 //Factory
-Addon* Addon::factory(rinad::RINAConfiguration& conf,
-		      const std::string& conf_file,
+Addon* Addon::factory(rinad::RINAConfiguration& config,
 		      const std::string& name){
 
 	Addon* addon = NULL;
@@ -47,9 +46,9 @@ Addon* Addon::factory(rinad::RINAConfiguration& conf,
 		//TODO this is a transitory solution. A proper auto-registering
 		// to the factory would be the right way to go
 		if(name == "mad"){
-			addon = new mad::ManagementAgent(conf_file);
+			addon = new mad::ManagementAgent(config);
 		}else if(name == "console"){
-			addon = new IPCMConsole(conf.local.consolePort);
+			addon = new IPCMConsole(config.local.consolePort);
 		}else if(name == "scripting"){
 			addon = new ScriptingEngine();
 		}else{

--- a/rinad/src/ipcm/addon.cc
+++ b/rinad/src/ipcm/addon.cc
@@ -47,7 +47,7 @@ Addon* Addon::factory(rinad::RINAConfiguration& conf,
 		//TODO this is a transitory solution. A proper auto-registering
 		// to the factory would be the right way to go
 		if(name == "mad"){
-			addon = new mad::ManagementAgent(std::string(""));
+			addon = new mad::ManagementAgent(conf_file);
 		}else if(name == "console"){
 			addon = new IPCMConsole(conf.local.consolePort);
 		}else if(name == "scripting"){

--- a/rinad/src/ipcm/addon.cc
+++ b/rinad/src/ipcm/addon.cc
@@ -37,7 +37,9 @@ rina::Lockable Addon::mutex;
 std::list<Addon*> Addon::event_subscribers;
 
 //Factory
-Addon* Addon::factory(rinad::RINAConfiguration& conf, const std::string& name){
+Addon* Addon::factory(rinad::RINAConfiguration& conf,
+		      const std::string& conf_file,
+		      const std::string& name){
 
 	Addon* addon = NULL;
 

--- a/rinad/src/ipcm/addon.h
+++ b/rinad/src/ipcm/addon.h
@@ -68,7 +68,6 @@ public:
 	* Factory
 	*/
 	static Addon* factory(rinad::RINAConfiguration& conf,
-			      const std::string& conf_name,
 			      const std::string& name);
 
 protected:

--- a/rinad/src/ipcm/addon.h
+++ b/rinad/src/ipcm/addon.h
@@ -68,7 +68,8 @@ public:
 	* Factory
 	*/
 	static Addon* factory(rinad::RINAConfiguration& conf,
-						const std::string& name);
+			      const std::string& conf_name,
+			      const std::string& name);
 
 protected:
 

--- a/rinad/src/ipcm/addons/console.cc
+++ b/rinad/src/ipcm/addons/console.cc
@@ -36,6 +36,7 @@
 #include <librina/common.h>
 #include <librina/ipc-manager.h>
 #include <librina/logs.h>
+#include <debug.h>
 
 #include "rina-configuration.h"
 #include "../ipcm.h"

--- a/rinad/src/ipcm/addons/ma/Makefile.am
+++ b/rinad/src/ipcm/addons/ma/Makefile.am
@@ -19,7 +19,8 @@ libaddons_ma_la_CPPFLAGS =			\
 	$(CPPFLAGS_EXTRA)			\
 	$(LIBRINA_CFLAGS)			\
 	-I$(srcdir)/../../../			\
-	-I$(srcdir)/../../../common
+	-I$(srcdir)/../../../common		\
+	-I${srcdir}/../../jsoncpp
 
 libaddons_ma_la_LIBADD = 			\
 	$(builddir)/../../../common/librinad.la	\

--- a/rinad/src/ipcm/addons/ma/agent.cc
+++ b/rinad/src/ipcm/addons/ma/agent.cc
@@ -168,7 +168,7 @@ RIBFactory* ManagementAgent::get_rib() const
 }
 
 //Initialization and destruction routines
-ManagementAgent::ManagementAgent(const std::string& conf_file) :
+ManagementAgent::ManagementAgent(const rinad::RINAConfiguration& config) :
 							AppAddon(MAD_NAME){
 
 	//Nice trace
@@ -177,7 +177,7 @@ ManagementAgent::ManagementAgent(const std::string& conf_file) :
 	//ConfManager must be initialized first, to
 	//proper configure the logging according to the cli level
 	//or the config file
-	conf_manager = new ConfManager(conf_file);
+	conf_manager = new ConfManager(config);
 
 	/*
 	* Initialize subsystems

--- a/rinad/src/ipcm/addons/ma/agent.cc
+++ b/rinad/src/ipcm/addons/ma/agent.cc
@@ -168,7 +168,7 @@ RIBFactory* ManagementAgent::get_rib() const
 }
 
 //Initialization and destruction routines
-ManagementAgent::ManagementAgent(const std::string& params) :
+ManagementAgent::ManagementAgent(const std::string& conf_file) :
 							AppAddon(MAD_NAME){
 
 	//Nice trace
@@ -177,7 +177,7 @@ ManagementAgent::ManagementAgent(const std::string& params) :
 	//ConfManager must be initialized first, to
 	//proper configure the logging according to the cli level
 	//or the config file
-	conf_manager = new ConfManager(params);
+	conf_manager = new ConfManager(conf_file);
 
 	/*
 	* Initialize subsystems

--- a/rinad/src/ipcm/addons/ma/agent.h
+++ b/rinad/src/ipcm/addons/ma/agent.h
@@ -82,7 +82,7 @@ class ManagementAgent : public AppAddon{
 public:
 
 	//Constructor and destructor
-	ManagementAgent(const std::string& params);
+	ManagementAgent(const rinad::RINAConfiguration& config);
 	~ManagementAgent(void);
 
 	/**

--- a/rinad/src/ipcm/addons/ma/confm.cc
+++ b/rinad/src/ipcm/addons/ma/confm.cc
@@ -18,14 +18,14 @@ namespace mad{
 Singleton<ConfManager> ConfManager;
 
 //Public constructor destructor
-ConfManager::ConfManager(const std::string& conf_file){
+ConfManager::ConfManager(const rinad::RINAConfiguration& config){
 
 	Json::Reader    reader;
 	Json::Value     root;
         Json::Value     mad_conf;
 	std::ifstream   fin;
 
-	fin.open(conf_file.c_str());
+	fin.open(config.configuration_file.c_str());
 	if (fin.fail()) {
 		LOG_ERR("Failed to open config file");
 		return;

--- a/rinad/src/ipcm/addons/ma/confm.cc
+++ b/rinad/src/ipcm/addons/ma/confm.cc
@@ -52,10 +52,11 @@ ConfManager::ConfManager(const std::string& conf_file){
         mad_conf = root["addons"]["mad"];
         if (mad_conf != 0) {
                 Json::Value nms_difs_conf = mad_conf["NMSDIFs"];
-                Json::Value mad_conns_conf = mad_conf["ManagerConnections"];
+                Json::Value mad_conns_conf = mad_conf["managerConnections"];
                 std::string app_name_enc;
 
-                app_name_enc = mad_conf.get("appName", app_name_enc).asString();
+                app_name_enc = mad_conf.get("managerAppName",
+                                        app_name_enc).asString();
                 if (app_name_enc != std::string()) {
                         app_name = rina::decode_apnameinfo(app_name_enc);
                 }
@@ -76,8 +77,9 @@ ConfManager::ConfManager(const std::string& conf_file){
                                 std::string app_name_enc;
                                 std::string dif;
 
-                                app_name_enc = mad_conns_conf[i].get("appName",
-                                                app_name_enc).asString();
+                                app_name_enc = mad_conns_conf[i]
+                                               .get("managerAppName",
+                                               app_name_enc).asString();
                                 dif = mad_conns_conf[i].get("DIF", dif)
                                                        .asString();
 

--- a/rinad/src/ipcm/addons/ma/confm.cc
+++ b/rinad/src/ipcm/addons/ma/confm.cc
@@ -111,32 +111,35 @@ ConfManager::ConfManager(const std::string& conf_file){
 }
 
 ConfManager::~ConfManager(){
-	//TODO
 }
 
 //Module configuration routine
 void ConfManager::configure(ManagementAgent& agent){
 
-	//Configure the AP nameand instance ID
-	//XXX get it from the configuration source (e.g. config file)
-	//Configure the MA
+	//Configure the AP name and instance ID
 	rina::ApplicationProcessNamingInformation info("rina.apps.mad", "1");
-	agent.setAPInfo(info);
-
+	agent.setAPInfo(app_name);
 
 	//NMS
-	std::string dif("normal.DIF");
-	agent.addNMSDIF(dif);
-
+        for (std::list<std::string>::iterator it = nms_difs.begin();
+                                        it != nms_difs.end(); it++) {
+	        agent.addNMSDIF(*it);
+        }
 
 	//Configure Manager connections
-	AppConnection ap_con;
-	ap_con.flow_info.remoteAppName =
-		rina::ApplicationProcessNamingInformation("rina.apps.manager", "1");
-	ap_con.flow_info.difName =
-		rina::ApplicationProcessNamingInformation(dif, "");
+        for (std::list<ManagerConnInfo>::iterator
+                        it = manager_connections.begin();
+                                it != manager_connections.end(); it++) {
+                AppConnection ap_con;
 
-	agent.addManagerConnection(ap_con);
+                ap_con.flow_info.remoteAppName = it->manager_name;
+                ap_con.flow_info.difName =
+                        rina::ApplicationProcessNamingInformation(
+                                        it->manager_dif, std::string());
+
+	        agent.addManagerConnection(ap_con);
+        }
+
 	//TODO
 }
 

--- a/rinad/src/ipcm/addons/ma/confm.cc
+++ b/rinad/src/ipcm/addons/ma/confm.cc
@@ -3,6 +3,10 @@
 
 #define RINA_PREFIX "ipcm.mad.conf"
 #include <librina/logs.h>
+#include <debug.h>
+
+#include <fstream>
+#include <sstream>
 
 #include "json/json.h"
 
@@ -13,10 +17,31 @@ namespace mad{
 Singleton<ConfManager> ConfManager;
 
 //Public constructor destructor
-ConfManager::ConfManager(const std::string& params){
+ConfManager::ConfManager(const std::string& conf_file){
 
-	(void)params;
 	//TODO: read config and get logging level and file
+
+	Json::Reader reader;
+	Json::Value  root;
+	std::ifstream     fin;
+
+	fin.open(conf_file.c_str());
+	if (fin.fail()) {
+		LOG_ERR("Failed to open config file");
+		return;
+	}
+
+	if (!reader.parse(fin, root, false)) {
+		std::stringstream ss;
+
+		ss << "Failed to parse JSON configuration" << std::endl
+			<< reader.getFormatedErrorMessages() << std::endl;
+		FLUSH_LOG(ERR, ss);
+
+		return;
+	}
+
+	fin.close();
 
 	LOG_DBG("Initialized");
 }

--- a/rinad/src/ipcm/addons/ma/confm.cc
+++ b/rinad/src/ipcm/addons/ma/confm.cc
@@ -3,6 +3,7 @@
 
 #define RINA_PREFIX "ipcm.mad.conf"
 #include <librina/logs.h>
+#include <librina/common.h>
 #include <debug.h>
 
 #include <fstream>
@@ -19,11 +20,10 @@ Singleton<ConfManager> ConfManager;
 //Public constructor destructor
 ConfManager::ConfManager(const std::string& conf_file){
 
-	//TODO: read config and get logging level and file
-
-	Json::Reader reader;
-	Json::Value  root;
-	std::ifstream     fin;
+	Json::Reader    reader;
+	Json::Value     root;
+        Json::Value     mad_conf;
+	std::ifstream   fin;
 
 	fin.open(conf_file.c_str());
 	if (fin.fail()) {
@@ -42,6 +42,68 @@ ConfManager::ConfManager(const std::string& conf_file){
 	}
 
 	fin.close();
+
+        // Set default values for MAD configuration variables
+        app_name = rina::ApplicationProcessNamingInformation("rina.apps.mad",
+                                                             "1");
+
+        // Parse MAD configuration from JSON, overwriting default configuration
+        // variables
+        mad_conf = root["addons"]["mad"];
+        if (mad_conf != 0) {
+                Json::Value nms_difs_conf = mad_conf["NMSDIFs"];
+                Json::Value mad_conns_conf = mad_conf["ManagerConnections"];
+                std::string app_name_enc;
+
+                app_name_enc = mad_conf.get("appName", app_name_enc).asString();
+                if (app_name_enc != std::string()) {
+                        app_name = rina::decode_apnameinfo(app_name_enc);
+                }
+
+                if (nms_difs_conf != 0) {
+                        for (unsigned i = 0; i < nms_difs_conf.size(); i++) {
+                                std::string dif;
+
+                                dif = nms_difs_conf[i]
+                                        .get("DIF", dif).asString();
+                                nms_difs.push_back(dif);
+                        }
+                }
+
+                if (mad_conns_conf != 0) {
+                        for (unsigned i = 0; i< mad_conns_conf.size(); i++) {
+                                ManagerConnInfo mci;
+                                std::string app_name_enc;
+                                std::string dif;
+
+                                app_name_enc = mad_conns_conf[i].get("appName",
+                                                app_name_enc).asString();
+                                dif = mad_conns_conf[i].get("DIF", dif)
+                                                       .asString();
+
+                                mci.manager_name =
+                                        rina::decode_apnameinfo(app_name_enc);
+                                mci.manager_dif = dif;
+                                manager_connections.push_back(mci);
+                        }
+                }
+        }
+
+        LOG_INFO("MAD application name will be %s",
+                 app_name.toString().c_str());
+
+        for (std::list<std::string>::iterator it = nms_difs.begin();
+                                        it != nms_difs.end(); it++) {
+                LOG_INFO("MAD NMS DIF %s", it->c_str());
+        }
+
+        for (std::list<ManagerConnInfo>::iterator
+                        it = manager_connections.begin();
+                                it != manager_connections.end(); it++) {
+                LOG_INFO("MAD Manager connection Name=%s DIF=%s",
+                                it->manager_name.toString().c_str(),
+                                it->manager_dif.c_str());
+        }
 
 	LOG_DBG("Initialized");
 }

--- a/rinad/src/ipcm/addons/ma/confm.cc
+++ b/rinad/src/ipcm/addons/ma/confm.cc
@@ -4,6 +4,8 @@
 #define RINA_PREFIX "ipcm.mad.conf"
 #include <librina/logs.h>
 
+#include "json/json.h"
+
 namespace rinad{
 namespace mad{
 

--- a/rinad/src/ipcm/addons/ma/confm.h
+++ b/rinad/src/ipcm/addons/ma/confm.h
@@ -26,6 +26,7 @@
 #include <list>
 #include <librina/application.h>
 #include <librina/common.h>
+#include <rina-configuration.h>
 
 /**
 * @file configuration.h
@@ -51,7 +52,7 @@ public:
 	/**
 	* Initialize running state
 	*/
-	ConfManager(const std::string& conf_file);
+	ConfManager(const rinad::RINAConfiguration& config);
 
 	/**
 	* Destroy the running state

--- a/rinad/src/ipcm/addons/ma/confm.h
+++ b/rinad/src/ipcm/addons/ma/confm.h
@@ -50,7 +50,7 @@ public:
 	/**
 	* Initialize running state
 	*/
-	ConfManager(const std::string& params);
+	ConfManager(const std::string& conf_file);
 
 	/**
 	* Destroy the running state

--- a/rinad/src/ipcm/addons/ma/confm.h
+++ b/rinad/src/ipcm/addons/ma/confm.h
@@ -23,6 +23,7 @@
 
 #include <assert.h>
 #include <string>
+#include <list>
 #include <librina/application.h>
 #include <librina/common.h>
 
@@ -65,6 +66,17 @@ public:
 
 private:
 
+        struct ManagerConnInfo {
+                rina::ApplicationProcessNamingInformation manager_name;
+                std::string manager_dif;
+        };
+
+        /**
+        * Internal variables containing MAD configuration
+        */
+        rina::ApplicationProcessNamingInformation app_name;
+        std::list<std::string> nms_difs;
+        std::list<ManagerConnInfo> manager_connections;
 };
 
 

--- a/rinad/src/ipcm/app-handlers.cc
+++ b/rinad/src/ipcm/app-handlers.cc
@@ -28,6 +28,7 @@
 #include <librina/common.h>
 #include <librina/ipc-manager.h>
 #include <librina/logs.h>
+#include <debug.h>
 
 #include "rina-configuration.h"
 #include "app-handlers.h"

--- a/rinad/src/ipcm/configuration.cc
+++ b/rinad/src/ipcm/configuration.cc
@@ -905,6 +905,7 @@ bool parse_configuration(std::string& file_loc)
         // Get everything in our data structures
         rinad::RINAConfiguration config;
 
+	config.configuration_file = file_loc;
         parse_local_conf(root, config.local);
         parse_app_to_dif(root, config.applicationToDIFMappings);
         parse_ipc_to_create(root, config.ipcProcessesToCreate);

--- a/rinad/src/ipcm/flow-alloc-handlers.cc
+++ b/rinad/src/ipcm/flow-alloc-handlers.cc
@@ -28,6 +28,7 @@
 
 #include <librina/common.h>
 #include <librina/ipc-manager.h>
+#include <debug.h>
 
 #define RINA_PREFIX "ipcm.flow-alloc"
 #include <librina/logs.h>

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -112,8 +112,7 @@ void IPCManager_::init(const std::string& loglevel)
 }
 
 void
-IPCManager_::load_addons(const std::string& addon_list,
-			 const string& conf_file){
+IPCManager_::load_addons(const std::string& addon_list){
 
 	std::string al = addon_list;
 
@@ -127,7 +126,7 @@ IPCManager_::load_addons(const std::string& addon_list,
 		//Remove whitespaces
 		t.erase(std::remove_if( t.begin(), t.end(), ::isspace ),
 								t.end() );
-		Addon* addon = Addon::factory(config, conf_file, t);
+		Addon* addon = Addon::factory(config, t);
 
 		if(!addon){
 			LOG_CRIT("Unable to bootstrap addon '%s'. Aborting...",

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -111,7 +111,8 @@ void IPCManager_::init(const std::string& loglevel)
 }
 
 void
-IPCManager_::load_addons(const std::string& addon_list){
+IPCManager_::load_addons(const std::string& addon_list,
+			 const string& conf_file){
 
 	std::string al = addon_list;
 
@@ -125,7 +126,7 @@ IPCManager_::load_addons(const std::string& addon_list){
 		//Remove whitespaces
 		t.erase(std::remove_if( t.begin(), t.end(), ::isspace ),
 								t.end() );
-		Addon* addon = Addon::factory(config, t);
+		Addon* addon = Addon::factory(config, conf_file, t);
 
 		if(!addon){
 			LOG_CRIT("Unable to bootstrap addon '%s'. Aborting...",

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -32,6 +32,7 @@
 
 #define RINA_PREFIX "ipcm"
 #include <librina/logs.h>
+#include <debug.h>
 
 #include "rina-configuration.h"
 #include "ipcm.h"

--- a/rinad/src/ipcm/ipcm.h
+++ b/rinad/src/ipcm/ipcm.h
@@ -260,7 +260,8 @@ public:
 	// Load the specified addons
 	//
 	// @param addons Comma separated list of addons
-	void load_addons(const std::string& addon_list);
+	void load_addons(const std::string& addon_list,
+			 const std::string& conf_file);
 
 	//
 	// TODO: XXX?????

--- a/rinad/src/ipcm/ipcm.h
+++ b/rinad/src/ipcm/ipcm.h
@@ -251,8 +251,7 @@ public:
 	// Load the specified addons
 	//
 	// @param addons Comma separated list of addons
-	void load_addons(const std::string& addon_list,
-			 const std::string& conf_file);
+	void load_addons(const std::string& addon_list);
 
 	//
 	// TODO: XXX?????

--- a/rinad/src/ipcm/ipcm.h
+++ b/rinad/src/ipcm/ipcm.h
@@ -48,15 +48,6 @@
 #define PROMISE_RETRY_NSEC 10000000 //10ms
 #define _PROMISE_1_SEC_NSEC 1000000000
 
-#ifndef FLUSH_LOG
-	//Force log flushing
-	#define FLUSH_LOG(_lev_, _ss_)\
-			do{\
-				LOGF_##_lev_ ("%s", (_ss_).str().c_str());\
-				ss.str(string());\
-			}while (0)
-#endif //FLUSH_LOG
-
 namespace rinad {
 
 //

--- a/rinad/src/ipcm/ipcp-handlers.cc
+++ b/rinad/src/ipcm/ipcp-handlers.cc
@@ -28,6 +28,7 @@
 
 #include <librina/common.h>
 #include <librina/ipc-manager.h>
+#include <debug.h>
 
 #define RINA_PREFIX "ipcm.ipcp"
 #include <librina/logs.h>

--- a/rinad/src/ipcm/main.cc
+++ b/rinad/src/ipcm/main.cc
@@ -148,7 +148,7 @@ int wrapped_main(int argc, char * argv[])
 		rinad::IPCManager->dumpConfig();
 
 	//Load addons
-	rinad::IPCManager->load_addons(addons);
+	rinad::IPCManager->load_addons(addons, conf);
 
 	//Run the loop
 	rinad::IPCManager->run();

--- a/rinad/src/ipcm/main.cc
+++ b/rinad/src/ipcm/main.cc
@@ -148,7 +148,7 @@ int wrapped_main(int argc, char * argv[])
 		rinad::IPCManager->dumpConfig();
 
 	//Load addons
-	rinad::IPCManager->load_addons(addons, conf);
+	rinad::IPCManager->load_addons(addons);
 
 	//Run the loop
 	rinad::IPCManager->run();

--- a/rinad/src/ipcm/misc-handlers.cc
+++ b/rinad/src/ipcm/misc-handlers.cc
@@ -31,6 +31,7 @@
 
 #define RINA_PREFIX "ipcm.misc"
 #include <librina/logs.h>
+#include <debug.h>
 
 #include "rina-configuration.h"
 #include "misc-handlers.h"

--- a/rinad/src/ipcm/policies-handlers.cc
+++ b/rinad/src/ipcm/policies-handlers.cc
@@ -27,6 +27,7 @@
 
 #include <librina/common.h>
 #include <librina/ipc-manager.h>
+#include <debug.h>
 
 #define RINA_PREFIX "ipcm.policies"
 #include <librina/logs.h>

--- a/tests/conf/ipcmanager.conf-mad
+++ b/tests/conf/ipcmanager.conf-mad
@@ -1,0 +1,144 @@
+{
+    "localConfiguration": {
+        "installationPath": "/home/vmaffione/irati/local/bin",
+        "libraryPath": "/home/vmaffione/irati/local/lib",
+        "logPath": "/home/vmaffione/irati/local/log",
+        "consolePort": 32766
+    },
+    "applicationToDIFMappings": [
+        {
+            "encodedAppName": "rina.apps.echotime.server-1--",
+            "difName": "normal.DIF"
+        },
+        {
+            "encodedAppName": "rina.apps.echotime.client-1--",
+            "difName": "normal.DIF"
+        }
+    ],
+    "ipcProcessesToCreate": [
+        {
+            "apName": "normal-1.IPCP",
+            "apInstance": "1",
+            "difName": "normal.DIF",
+            "difsToRegisterAt": [
+            ]
+        }
+    ],
+    "difConfigurations": [
+        {
+            "difName": "normal.DIF",
+            "difType": "normal-ipc",
+            "dataTransferConstants": {
+                "addressLength": 2,
+                "cepIdLength": 2,
+                "lengthLength": 2,
+                "portIdLength": 2,
+                "qosIdLength": 2,
+                "sequenceNumberLength": 4,
+                "maxPduSize": 10000,
+                "maxPduLifetime": 30
+            },
+            "configParameters": {
+                "bar": "foo"
+            },
+            "qosCubes": [
+                {
+                    "name": "unreliablewithflowcontrol",
+                    "id": 1,
+                    "partialDelivery": false,
+                    "orderedDelivery": false,
+                    "efcpPolicies": {
+                        "dtcpPresent": true,
+                        "dtcpConfiguration": {
+                            "rtxcontrol": false,
+                            "flowcontrol": true,
+                            "flowcontrolconfig": {
+                                "ratebased": false,
+                                "windowbased": true,
+                                "windowbasedconfig": {
+                                    "maxclosedwindowqueuelength": 200,
+                                    "initialcredit": 50
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "reliablewithflowcontrol",
+                    "id": 2,
+                    "partialDelivery": false,
+                    "orderedDelivery": false,
+                    "efcpPolicies": {
+                        "dtcpPresent": true,
+                        "dtcpConfiguration": {
+                            "rtxcontrol": true,
+                            "rtxcontrolconfig": {
+                                "datarxmsnmax": 5,
+                                "initialRtxTime": 20
+                            },
+                            "flowcontrol": true,
+                            "flowcontrolconfig": {
+                                "ratebased": false,
+                                "windowbased": true,
+                                "windowbasedconfig": {
+                                    "maxclosedwindowqueuelength": 200,
+                                    "initialcredit": 50
+                                }
+                            }
+                        }
+                    }
+                }
+            ],
+            "knownIPCProcessAddresses": [
+                {
+                    "apName": "normal-1.IPCP",
+                    "apInstance": "1",
+                    "address": 16
+                },
+                {
+                    "apName": "normal-2.IPCP",
+                    "apInstance": "1",
+                    "address": 17
+                }
+            ],
+            "pdufTableGeneratorConfiguration": {
+                "pduFtGeneratorPolicy": {
+                    "name": "LinkState",
+                    "version": "0"
+                },
+                "linkStateRoutingConfiguration": {
+                    "objectMaximumAge": 10000,
+                    "waitUntilReadCDAP": 5001,
+                    "waitUntilError": 5001,
+                    "waitUntilPDUFTComputation": 103,
+                    "waitUntilFSODBPropagation": 101,
+                    "waitUntilAgeIncrement": 997,
+                    "routingAlgorithm": "Dijkstra"
+                }
+            },
+                "enrollmentTaskConfiguration" : {
+                    "enrollTimeoutInMs" : 10000,
+                        "watchdogPeriodInMs" : 30000,
+                        "declaredDeadIntervalInMs" : 120000,
+                        "neighborsEnrollerPeriodInMs" : 30000,
+                        "maxEnrollmentRetries" : 3
+                }
+        }
+    ],
+    "addons" : {
+        "mad" : {
+            "managerAppName" : "mad-1--",
+            "NMSDIFs" : [
+                {
+                    "DIF": "normal.DIF"
+                }
+            ],
+            "managerConnections" : [
+                {
+                    "managerAppName" : "rina.apps.manager-1--",
+                    "DIF" : "normal.DIF"
+                }
+            ]
+        }
+    }
+}

--- a/tests/conf/ipcmanager.conf-mad
+++ b/tests/conf/ipcmanager.conf-mad
@@ -1,8 +1,8 @@
 {
     "localConfiguration": {
-        "installationPath": "/home/vmaffione/irati/local/bin",
-        "libraryPath": "/home/vmaffione/irati/local/lib",
-        "logPath": "/home/vmaffione/irati/local/log",
+        "installationPath": "/usr/local/irati/bin",
+        "libraryPath": "/usr/local/irati/lib",
+        "logPath": "/usr/local/irati/var/log",
         "consolePort": 32766
     },
     "applicationToDIFMappings": [
@@ -127,7 +127,7 @@
     ],
     "addons" : {
         "mad" : {
-            "managerAppName" : "mad-1--",
+            "managerAppName" : "rina.apps.mad-1--",
             "NMSDIFs" : [
                 {
                     "DIF": "normal.DIF"


### PR DESCRIPTION
Add basic configuration file support for mad.
The configuration file path is passed to the MAD constructor from the Addon factory, and then internally delivered to the MAD configuration manager. Here the configuration is parsed again, and only the MAD-specific configuration is considered.

The choice to parse the JSON again in the MAD configuration manager (it is already parsed by the IPCM itself) is due to the fact that JSON is a temporary solution, so it is convenient to avoid to use the JSONCPP library as less as possible in the IPCM/MA code.

Information taken from the configuration file is then used to configure the MA - while the previous implementation used to hardcode the configuration parameters.

An example configuration file is provided in tests/conf.
