### PR TITLE
Rib v3 bernat

### DIFF
--- a/librina/include/librina/rib_v2.h
+++ b/librina/include/librina/rib_v2.h
@@ -191,33 +191,6 @@ public:
 			const cdap_rib::res_info_t &res) = 0;
 };
 
-class AbstractEncoder {
-
-public:
-	virtual ~AbstractEncoder();
-};
-
-template<class T>
-class Encoder: public AbstractEncoder {
-
-public:
-	virtual ~Encoder(){}
-
-	/// Converts an object to a byte array, if this object is recognized by the encoder
-	/// @param object
-	/// @throws exception if the object is not recognized by the encoder
-	/// @return
-	virtual void encode(const T &obj, cdap_rib::ser_obj_t& serobj) = 0;
-	/// Converts a byte array to an object of the type specified by "className"
-	/// @param byte[] serializedObject
-	/// @param objectClass The type of object to be decoded
-	/// @throws exception if the byte array is not an encoded in a way that the
-	/// encoder can recognize, or the byte array value doesn't correspond to an
-	/// object of the type "className"
-	/// @return
-	virtual void decode(const cdap_rib::ser_obj_t &serobj,
-			T& des_obj) = 0;
-};
 
 ///
 /// Base RIB Object. API for the create/delete/read/write/start/stop RIB
@@ -429,13 +402,6 @@ protected:
 	///
 	void operation_not_supported(cdap_rib::res_info_t& res);
 
-	///
-	/// Get the encoder
-	///
-	/// TODO: remove?
-	///
-	virtual AbstractEncoder* get_encoder() = 0;
-
 	///Rwlock
 	rina::ReadWriteLockable rwlock;
 
@@ -461,7 +427,6 @@ public:
 	const std::string& get_class() const{
 		return class_;
 	};
-	AbstractEncoder* get_encoder(){return NULL;}
 
 private:
 	RootObj(void) : RIBObj(), class_("root") { };
@@ -548,27 +513,6 @@ private:
 	unsigned max_objs_;
 };
 
-//
-// EmptyClass (really?)
-//
-class EmptyClass {};
-
-class EmptyEncoder : public rib::Encoder<EmptyClass> {
-
-public:
-	virtual void encode(const EmptyClass &obj, cdap_rib::SerializedObject& serobj){
-		(void)serobj;
-		(void)obj;
-	};
-	virtual void decode(const cdap_rib::SerializedObject &serobj,
-			EmptyClass& des_obj){
-		(void)serobj;
-		(void)des_obj;
-	};
-	std::string get_type() const{
-		return "EmptyClass";
-	};
-};
 
 //fwd decl
 class RIBDaemon;

--- a/librina/src/rib_v2.cc
+++ b/librina/src/rib_v2.cc
@@ -1101,8 +1101,6 @@ int64_t RIB::add_obj(const std::string& fqn, RIBObj* obj) {
 		}
 		parent_child_list->push_back(id);
 
-		//Mark pointer as acquired and return
-		obj = NULL;
 		LOG_DBG("Object '%s' of class '%s' succesfully added (id:'%" PRId64 "')",
 									fqn.c_str(),
 									obj->get_class().c_str(),

--- a/librina/src/rib_v2.cc
+++ b/librina/src/rib_v2.cc
@@ -2412,12 +2412,6 @@ void RIBDaemon::stop_request(const cdap_rib::con_handle_t &con,
 	rib->stop_request(con, obj, filt, invoke_id);
 }
 
-//
-// Encoder AbstractEncoder and base class
-//
-
-AbstractEncoder::~AbstractEncoder() {
-}
 
 //RIBObj/RIBObj_
 void RIBObj::create(const cdap_rib::con_handle_t &con,

--- a/librina/src/rib_v2.cc
+++ b/librina/src/rib_v2.cc
@@ -116,11 +116,9 @@ public:
 						const std::string& fqn_,
 						create_cb_t cb);
 private:
-	template<typename T>
-	bool validateAddObject(const RIBObj<T>* obj);
-	template<typename T, typename R>
-	bool validateRemoveObject(const RIBObj<T>* obj,
-			const RIBObj<R>* parent);
+	bool validateAddObject(const RIBObj* obj);
+	bool validateRemoveObject(const RIBObj* obj,
+			const RIBObj* parent);
 	const cdap_rib::vers_info_t version;
 	std::map<std::string, RIBSchemaObject*> rib_schema;
 	const char separator;
@@ -179,8 +177,8 @@ rib_schema_res RIBSchema::ribSchemaDefContRelation(
 	return (ret.second)? RIB_SUCCESS : RIB_SCHEMA_FORMAT_ERR;
 }
 
-template<typename T>
-bool RIBSchema::validateAddObject(const RIBObj<T>* obj) {
+
+bool RIBSchema::validateAddObject(const RIBObj* obj) {
 
 	(void) obj;
 
@@ -285,7 +283,7 @@ public:
 	///
 	/// @ret instance_id of the objc
 	///
-	int64_t add_obj(const std::string& fqn, RIBObj_** obj);
+	int64_t add_obj(const std::string& fqn, RIBObj* obj);
 
 	//
 	// Get the instance id of an object given a fully qualified name (fqn)
@@ -314,23 +312,6 @@ public:
 	//	does not exist
 	//
 	std::string get_obj_class(const int64_t instance_id);
-
-	//
-	// Get (a copy) of the user data from an object
-	//
-	// @param inst_id The instance id of the object
-	//
-	template <typename T>
-	T get_obj_user_data(const int64_t inst_id);
-
-	//
-	// Set (copy) the user data to an object
-	//
-	// @param inst_id The instance id of the object
-	// @param user_data_ The new user data (T)
-	//
-	template <typename T>
-	void set_obj_user_data(const int64_t inst_id, T user_data_);
 
 	///
 	/// Get the RIB's path separator
@@ -409,10 +390,10 @@ protected:
 private:
 
 	// fqn <-> obj
-	std::map<std::string, RIBObj_*> obj_name_map;
+	std::map<std::string, RIBObj*> obj_name_map;
 
 	// instance id <-> obj
-	std::map<int64_t, RIBObj_*> obj_inst_map;
+	std::map<int64_t, RIBObj*> obj_inst_map;
 
 	// instance id <-> fqn
 	std::map<int64_t, std::string> inst_name_map;
@@ -436,7 +417,7 @@ private:
 	unsigned int num_of_deleg;
 
 	//@internal only; must be called with the rwlock acquired
-	RIBObj_* get_obj(int64_t inst_id);
+	RIBObj* get_obj(int64_t inst_id);
 
 	//@internal: must be called with the rwlock acquired
 	void __remove_obj(int64_t inst_id);
@@ -485,7 +466,7 @@ RIB::RIB(const rib_handle_t& handle_, RIBSchema *const schema_,
 	std::stringstream root_fqn;
 
 	//Create root object
-	RIBObj_* root = new RootObj();
+	RIBObj* root = new RootObj();
 
 	// Root fqn
 	root_fqn << schema->get_root_name() << schema->get_separator();
@@ -526,7 +507,7 @@ void RIB::create_request(const cdap_rib::con_handle_t &con,
 	obj_reply.value_.message_ = NULL;
 
 	cdap_rib::res_info_t res;
-	RIBObj_* rib_obj = NULL;
+	RIBObj* rib_obj = NULL;
 
 	/* RAII scope for RIB scoped lock (read) */
 	{
@@ -592,7 +573,7 @@ void RIB::delete_request(const cdap_rib::con_handle_t &con,
 	// FIXME add res and flags
 	cdap_rib::flags_t flags;
 	cdap_rib::res_info_t res;
-	RIBObj_* rib_obj = NULL;
+	RIBObj* rib_obj = NULL;
 	bool delete_flag = false;
 	int64_t id;
 
@@ -661,7 +642,7 @@ void RIB::read_request(const cdap_rib::con_handle_t &con,
 	obj_reply.value_.message_ = NULL;
 
 	cdap_rib::res_info_t res;
-	RIBObj_* rib_obj = NULL;
+	RIBObj* rib_obj = NULL;
 
 	/* RAII scope for RIB scoped lock (read) */
 	{
@@ -711,7 +692,7 @@ void RIB::cancel_read_request(
 	// FIXME add res and flags
 	cdap_rib::flags_t flags;
 	cdap_rib::res_info_t res;
-	RIBObj_* rib_obj = NULL;
+	RIBObj* rib_obj = NULL;
 
 	/* RAII scope for RIB scoped lock (read) */
 	{
@@ -764,7 +745,7 @@ void RIB::write_request(const cdap_rib::con_handle_t &con,
 	obj_reply.value_.message_ = NULL;
 
 	cdap_rib::res_info_t res;
-	RIBObj_* rib_obj = NULL;
+	RIBObj* rib_obj = NULL;
 
 	/* RAII scope for RIB scoped lock (read) */
 	{
@@ -822,7 +803,7 @@ void RIB::start_request(const cdap_rib::con_handle_t &con,
 	obj_reply.value_.message_ = NULL;
 
 	cdap_rib::res_info_t res;
-	RIBObj_* rib_obj = NULL;
+	RIBObj* rib_obj = NULL;
 
 	/* RAII scope for RIB scoped lock (read) */
 	{
@@ -879,7 +860,7 @@ void RIB::stop_request(const cdap_rib::con_handle_t &con,
 	obj_reply.value_.message_ = NULL;
 
 	cdap_rib::res_info_t res;
-	RIBObj_* rib_obj = NULL;
+	RIBObj* rib_obj = NULL;
 
 	/* RAII scope for RIB scoped lock (read) */
 	{
@@ -920,7 +901,7 @@ void RIB::stop_request(const cdap_rib::con_handle_t &con,
 }
 
 
-RIBObj_* RIB::get_obj(int64_t inst_id){
+RIBObj* RIB::get_obj(int64_t inst_id){
 	if(obj_inst_map.find(inst_id) != obj_inst_map.end())
 		return obj_inst_map[inst_id];
 	else
@@ -939,6 +920,7 @@ int64_t RIB::__get_obj_inst_id(const std::string& fqn){
 	if(id == -1 && num_of_deleg > 0){
 
 		/* rwlock RAII scope */ {
+
 			ReadScopedLock rlock(cache_rwlock);
 
 			//Check cache
@@ -966,7 +948,7 @@ int64_t RIB::__get_obj_inst_id(const std::string& fqn){
 			return id;
 
 		//Check if it is a delegated obj
-		RIBObj_ *obj = get_obj(id);
+		RIBObj *obj = get_obj(id);
 		if(!obj){
 			assert(0); // neither this one
 			return -1;
@@ -1040,26 +1022,23 @@ void RIB::__validate_fqn(const std::string& fqn){
 	}
 }
 
-int64_t RIB::add_obj(const std::string& fqn, RIBObj_** obj_) {
+int64_t RIB::add_obj(const std::string& fqn, RIBObj* obj) {
 
 	int64_t id, parent_id;
 	std::string parent_fqn = get_parent_fqn(fqn);
-	RIBObj_* obj;
 
-	if(!(*obj_)){
+	if(!obj){
 		LOG_ERR("Unable to add object(%p) at '%s'; object is NULL!",
-								*obj_,
+								obj,
 								fqn.c_str());
 		throw eObjInvalid();
 	}
 	LOG_DBG("Starting add object operation over RIB(%p), of object(%p) with fqn: '%s' (parent '%s')",
 							this,
-							*obj_,
+							obj,
 							fqn.c_str(),
 							parent_fqn.c_str());
 
-	//Recover the non-templatized part
-	obj = *obj_;
 
 	//Validate the name
 	__validate_fqn(fqn);
@@ -1123,7 +1102,7 @@ int64_t RIB::add_obj(const std::string& fqn, RIBObj_** obj_) {
 		parent_child_list->push_back(id);
 
 		//Mark pointer as acquired and return
-		*obj_ = NULL;
+		obj = NULL;
 		LOG_DBG("Object '%s' of class '%s' succesfully added (id:'%" PRId64 "')",
 									fqn.c_str(),
 									obj->get_class().c_str(),
@@ -1132,7 +1111,7 @@ int64_t RIB::add_obj(const std::string& fqn, RIBObj_** obj_) {
 
 	LOG_DBG("Add object operation over RIB(%p), of object(%p) with fqn: '%s', succeeded. Instance id: '%" PRId64 "'",
 								this,
-								*obj_,
+								obj,
 								fqn.c_str(),
 								id);
 
@@ -1142,7 +1121,7 @@ int64_t RIB::add_obj(const std::string& fqn, RIBObj_** obj_) {
 
 void RIB::__remove_obj(int64_t inst_id) {
 
-	RIBObj_* obj;
+	RIBObj* obj;
 	std::list<int64_t> *child_list = NULL, *parent_child_list = NULL;
 	std::list<int64_t>::iterator it;
 	int64_t parent_inst_id;
@@ -1249,7 +1228,7 @@ std::string RIB::get_obj_class(const int64_t inst_id){
 }
 
 std::string RIB::__get_obj_class(const int64_t inst_id){
-	RIBObj_* obj;
+	RIBObj* obj;
 
 	obj = get_obj(inst_id);
 
@@ -1391,7 +1370,7 @@ public:
 	/// @throws eRIBNotFound, eObjExists
 	///
 	int64_t addObjRIB(const rib_handle_t& handle, const std::string& fqn,
-								RIBObj_** obj);
+								RIBObj* obj);
 
 	///
 	/// Retrieve the instance ID of an object given its fully
@@ -1949,7 +1928,6 @@ void RIBDaemon::remove_connection(const cdap_rib::con_handle_t& con){
 
 void RIBDaemon::remote_open_connection_result(const cdap_rib::con_handle_t &con,
 		const cdap_rib::res_info_t &res) {
-
 	// FIXME remove invoke_id
 
 	app_con_callback_->connectResult(res, con);
@@ -1993,20 +1971,18 @@ void RIBDaemon::close_connection(const cdap_rib::con_handle_t &con,
 // Object management
 
 int64_t RIBDaemon::addObjRIB(const rib_handle_t& handle,
-					const std::string& fqn, RIBObj_** obj){
-
+					const std::string& fqn, RIBObj* obj){
 	if(obj == NULL)
 		throw Exception();
 
 	//Mutual exclusion
 	ReadScopedLock rlock(rwlock);
-
 	//Retreive the RIB
 	RIB* rib = getRIB(handle);
 
 	if(rib == NULL){
 		LOG_ERR("Could not add object(%p) to rib('%" PRId64 "'). RIB does not exist",
-								*obj,
+								obj,
 								handle);
 		throw eRIBNotFound();
 	}
@@ -2017,7 +1993,6 @@ int64_t RIBDaemon::addObjRIB(const rib_handle_t& handle,
 int64_t RIBDaemon::getObjInstId(const rib_handle_t& handle,
 				const std::string& fqn,
 				const std::string& class_){
-
 	int64_t id;
 
 	//Mutual exclusion
@@ -2447,7 +2422,7 @@ AbstractEncoder::~AbstractEncoder() {
 }
 
 //RIBObj/RIBObj_
-void RIBObj_::create(const cdap_rib::con_handle_t &con,
+void RIBObj::create(const cdap_rib::con_handle_t &con,
 				const std::string& fqn,
 				const std::string& class_,
 				const cdap_rib::filt_info_t &filt,
@@ -2466,7 +2441,7 @@ void RIBObj_::create(const cdap_rib::con_handle_t &con,
 	operation_not_supported(res);
 }
 
-bool RIBObj_::delete_(const cdap_rib::con_handle_t &con,
+bool RIBObj::delete_(const cdap_rib::con_handle_t &con,
 					const std::string& fqn,
 					const std::string& class_,
 					const cdap_rib::filt_info_t &filt,
@@ -2482,7 +2457,7 @@ bool RIBObj_::delete_(const cdap_rib::con_handle_t &con,
 }
 
 // FIXME remove name, it is not needed
-void RIBObj_::read(const cdap_rib::con_handle_t &con,
+void RIBObj::read(const cdap_rib::con_handle_t &con,
 					const std::string& fqn,
 					const std::string& class_,
 					const cdap_rib::filt_info_t &filt,
@@ -2498,7 +2473,7 @@ void RIBObj_::read(const cdap_rib::con_handle_t &con,
 	operation_not_supported(res);
 }
 
-void RIBObj_::cancelRead(const cdap_rib::con_handle_t &con,
+void RIBObj::cancelRead(const cdap_rib::con_handle_t &con,
 					const std::string& fqn,
 					const std::string& class_,
 					const cdap_rib::filt_info_t &filt,
@@ -2512,7 +2487,7 @@ void RIBObj_::cancelRead(const cdap_rib::con_handle_t &con,
 	operation_not_supported(res);
 }
 
-void RIBObj_::write(const cdap_rib::con_handle_t &con,
+void RIBObj::write(const cdap_rib::con_handle_t &con,
 				const std::string& fqn,
 				const std::string& class_,
 				const cdap_rib::filt_info_t &filt,
@@ -2530,7 +2505,7 @@ void RIBObj_::write(const cdap_rib::con_handle_t &con,
 	operation_not_supported(res);
 }
 
-void RIBObj_::start(const cdap_rib::con_handle_t &con,
+void RIBObj::start(const cdap_rib::con_handle_t &con,
 			const std::string& fqn,
 			const std::string& class_,
 			const cdap_rib::filt_info_t &filt,
@@ -2548,7 +2523,7 @@ void RIBObj_::start(const cdap_rib::con_handle_t &con,
 	operation_not_supported(res);
 }
 
-void RIBObj_::stop(const cdap_rib::con_handle_t &con,
+void RIBObj::stop(const cdap_rib::con_handle_t &con,
 			const std::string& fqn,
 			const std::string& class_,
 			const cdap_rib::filt_info_t &filt,
@@ -2566,7 +2541,7 @@ void RIBObj_::stop(const cdap_rib::con_handle_t &con,
 	operation_not_supported(res);
 }
 
-void RIBObj_::operation_not_supported(cdap_rib::res_info_t& res) {
+void RIBObj::operation_not_supported(cdap_rib::res_info_t& res) {
 	res.code_ = cdap_rib::CDAP_OP_NOT_SUPPORTED;
 }
 
@@ -2631,8 +2606,8 @@ rib_handle_t RIBDaemonProxy::get(const cdap_rib::vers_info_t& v,
 
 //RIB object mamangement
 
-int64_t RIBDaemonProxy::__addObjRIB(const rib_handle_t& h,
-					const std::string& fqn, RIBObj_** o){
+int64_t RIBDaemonProxy::addObjRIB(const rib_handle_t& h,
+					const std::string& fqn, RIBObj* o){
 	return ribd->addObjRIB(h, fqn, o);
 }
 

--- a/librina/test/Makefile.am
+++ b/librina/test/Makefile.am
@@ -123,7 +123,7 @@ check_PROGRAMS =				\
 	test-cdap				\
 	test-rib_v2
 
-XFAIL_TESTS =					\
+XFAIL_TESTS =				\	
 	test-03
 
 PASS_TESTS =					\

--- a/librina/test/test-01.cc
+++ b/librina/test/test-01.cc
@@ -77,14 +77,11 @@ bool checkRegisteredApplications(unsigned int expectedApps) {
 
 int main() {
 	std::cout << "TESTING LIBRINA-APPLICATION\n";
-	ApplicationProcessNamingInformation sourceName =
-			ApplicationProcessNamingInformation("/apps/test/source", "1");
-	ApplicationProcessNamingInformation destinationName =
-			ApplicationProcessNamingInformation("/apps/test/destination",
+	ApplicationProcessNamingInformation sourceName("/apps/test/source", "1");
+	ApplicationProcessNamingInformation destinationName("/apps/test/destination",
 					"1");
 	FlowSpecification flowSpecification;
-	ApplicationProcessNamingInformation difName =
-	                ApplicationProcessNamingInformation("test.DIF", "");
+	ApplicationProcessNamingInformation difName("test.DIF", "");
 
 	/* TEST ALLOCATE REQUEST */
 	unsigned int seqNumber = ipcManager->requestFlowAllocation(
@@ -108,7 +105,8 @@ int main() {
 			<< "; state is: " << flow2.state << "\n";
 
 	/* TEST READ SDU */
-	int bytesRead = ipcManager->readSDU(flow2.portId, (void*)sdu, 7);
+	int bytesRead = ipcManager->readSDU(flow2.portId, (void*)sdu, 5);
+
 	std::cout << "Read an SDU of " << bytesRead << " bytes. Contents: \n";
 	for (int i = 0; i < bytesRead; i++) {
 		std::cout << "SDU[" << i << "]: " << sdu[i] << "\n";
@@ -118,14 +116,12 @@ int main() {
 	if (!checkAllocatedFlows(2)) {
 		return 1;
 	}
-
 	/* TEST DEALLOCATE FLOW */
 	ipcManager->requestFlowDeallocation(flow.portId);
 	ipcManager->flowDeallocationResult(flow.portId, true);
 	if (!checkAllocatedFlows(1)) {
 		return 1;
 	}
-
 	ipcManager->requestFlowDeallocation(flow2.portId);
 	ipcManager->flowDeallocationResult(flow2.portId, true);
 	if (!checkAllocatedFlows(0)) {
@@ -137,7 +133,6 @@ int main() {
 	} catch (IPCException &e) {
 		std::cout << "Caught expected exception: " << e.what() << "\n";
 	}
-
 	/* TEST REGISTER APPLICATION */
 	ApplicationRegistrationInformation info =
 			 ApplicationRegistrationInformation(
@@ -149,7 +144,6 @@ int main() {
 	if (!checkRegisteredApplications(1)) {
 	        return -1;
 	}
-
 	/* TEST UNREGISTER APPLICATION */
 	seqNumber = ipcManager->requestApplicationUnregistration(sourceName, difName);
 	ipcManager->appUnregistrationResult(seqNumber, true);

--- a/librina/test/test-rib_v2.cc
+++ b/librina/test/test-rib_v2.cc
@@ -273,28 +273,6 @@ public:
 
 static CDAPProviderMockup cdap_provider_mockup;
 static cdap::CDAPCallbackInterface* rib_provider = NULL;
-//
-//
-//
-
-class MyObjEncoder: public Encoder<uint32_t> {
-
-public:
-	virtual ~MyObjEncoder(){}
-
-	void encode(const uint32_t &obj, cdap_rib::ser_obj_t& serobj){
-		//TODO fill in
-		(void)obj;
-		(void)serobj;
-	};
-
-	virtual void decode(const cdap_rib::ser_obj_t &serobj,
-							uint32_t& des_obj){
-		//TODO fill in
-		(void)serobj;
-		(void)des_obj;
-	};
-};
 
 //A type
 class MyObj : public RIBObj {
@@ -308,10 +286,6 @@ public:
 	const std::string& get_class() const{
 		return class_;
 	}
-
-	AbstractEncoder* get_encoder(){
-		return &encoder;
-	};
 
 	void read(const cdap_rib::con_handle_t &con,
 					const std::string& fqn,
@@ -337,7 +311,6 @@ public:
 		return true;
 	}
 
-	MyObjEncoder encoder;
 	static const std::string class_;
 	uint32_t initial_value_;
 };
@@ -357,10 +330,6 @@ public:
 		return class_;
 	}
 
-	AbstractEncoder* get_encoder(){
-		return &encoder;
-	};
-
 	void read(const cdap_rib::con_handle_t &con,
 					const std::string& fqn,
 					const std::string& class_,
@@ -370,9 +339,6 @@ public:
 					cdap_rib::res_info_t& res){
 	};
 
-
-
-	MyObjEncoder encoder;
 	static const std::string class_;
 	uint32_t initial_value_;
 };
@@ -392,9 +358,6 @@ public:
 		return class_;
 	}
 
-	AbstractEncoder* get_encoder(){
-		return &encoder;
-	};
 
 	void start(const cdap_rib::con_handle_t &con,
 				const std::string& fqn,
@@ -418,7 +381,6 @@ public:
 		deleg_start_operations++;
 	}
 
-	MyObjEncoder encoder;
 	static const std::string class_;
 };
 

--- a/librina/test/test-rib_v2.cc
+++ b/librina/test/test-rib_v2.cc
@@ -761,7 +761,6 @@ void ribBasicOps::testAssociation(){
 
 void ribBasicOps::testAddObj(){
 
-	MyObj* tmp;
 	rib_handle_t wrong_handle = 9999;
 	std::string invalid_name1 = "";
 	std::string invalid_name2 = "x";
@@ -810,11 +809,8 @@ void ribBasicOps::testAddObj(){
 
 	//Add the right object (/x)
 	try{
-		tmp = obj1;
 		inst_id1 = ribd->addObjRIB(handle, name1, obj1);
-		CPPUNIT_ASSERT_MESSAGE("Did not set to null obj1", obj1 == NULL);
 		CPPUNIT_ASSERT_MESSAGE("Invalid instance id for obj1", inst_id1 == 1);
-		obj1 = tmp;
 	}catch(...){
 		CPPUNIT_ASSERT_MESSAGE("Could not add obj with in a valid RIB", 0);
 	}
@@ -837,23 +833,19 @@ void ribBasicOps::testAddObj(){
 		CPPUNIT_ASSERT_MESSAGE("Exception thrown during utils API validation", 0);
 	}
 
-	tmp = obj2;
 	try{
 		ribd->addObjRIB(handle, name1, obj2);
 		CPPUNIT_ASSERT_MESSAGE("Add overlapping object to RIB succeeded", 0);
 	}catch(eObjExists& e){
-		CPPUNIT_ASSERT_MESSAGE("Add overlapping object failed, but modified the object pointer",  tmp == obj2);
+		CPPUNIT_ASSERT_MESSAGE("Add overlapping object failed", 1);
 	}catch(...){
 		CPPUNIT_ASSERT_MESSAGE("Invalid exception thrown during Add obj with an overlapping object", 0);
 	}
 
 	//Add another valid object (/y)
 	try{
-		tmp = obj2;
 		inst_id2 = ribd->addObjRIB(handle, name2, obj2);
-		CPPUNIT_ASSERT_MESSAGE("Did not set to null obj2", obj2 == NULL);
 		CPPUNIT_ASSERT_MESSAGE("Invalid instance id for obj2", inst_id2 == 2);
-		obj2 = tmp;
 	}catch(...){
 		CPPUNIT_ASSERT_MESSAGE("Could not add obj2 with in a valid RIB", 0);
 	}
@@ -875,23 +867,19 @@ void ribBasicOps::testAddObj(){
 	}
 
 	//Retry overlap should fail
-	tmp = obj2;
 	try{
 		ribd->addObjRIB(handle, name2, obj2);
 		CPPUNIT_ASSERT_MESSAGE("Add overlapping object to RIB succeeded", 0);
 	}catch(eObjExists& e){
-		CPPUNIT_ASSERT_MESSAGE("Add overlapping object failed, but modified the object pointer",  tmp == obj2);
+		CPPUNIT_ASSERT_MESSAGE("Add overlapping object failed", 1);
 	}catch(...){
 		CPPUNIT_ASSERT_MESSAGE("Invalid exception thrown during Add obj with an overlapping object", 0);
 	}
 
 	//Add an inner object (/x/z)
 	try{
-		tmp = obj3;
 		inst_id3 = ribd->addObjRIB(handle, name3, obj3);
-		CPPUNIT_ASSERT_MESSAGE("Did not set to null obj3", obj3 == NULL);
 		CPPUNIT_ASSERT_MESSAGE("Invalid instance id for obj3", inst_id3 == 3);
-		obj3 = tmp;
 	}catch(...){
 		CPPUNIT_ASSERT_MESSAGE("Exception thrown during Add obj 3", 0);
 	}
@@ -915,11 +903,8 @@ void ribBasicOps::testAddObj(){
 
 	//Add an inner object (/x/other)
 	try{
-		OtherObj* tmp2 = obj4;
 		inst_id4 = ribd->addObjRIB(handle, name_other, obj4);
-		CPPUNIT_ASSERT_MESSAGE("Did not set to null obj4", obj4 == NULL);
 		CPPUNIT_ASSERT_MESSAGE("Invalid instance id for obj4", inst_id4 == 4);
-		obj4 = tmp2;
 	}catch(...){
 		CPPUNIT_ASSERT_MESSAGE("Exception thrown during Add obj 4", 0);
 	}

--- a/librina/test/test-rib_v2.cc
+++ b/librina/test/test-rib_v2.cc
@@ -297,10 +297,12 @@ public:
 };
 
 //A type
-class MyObj : public RIBObj<uint32_t> {
+class MyObj : public RIBObj {
 
 public:
-	MyObj(uint32_t initial_value) : RIBObj<uint32_t>(initial_value){};
+	MyObj(uint32_t initial_value) : RIBObj(){
+		initial_value_ = initial_value;
+	};
 	virtual ~MyObj(){};
 
 	const std::string& get_class() const{
@@ -337,15 +339,18 @@ public:
 
 	MyObjEncoder encoder;
 	static const std::string class_;
+	uint32_t initial_value_;
 };
 
 const std::string MyObj::class_ = "MyObj";
 
 //Another type
-class OtherObj : public RIBObj<uint32_t> {
+class OtherObj : public RIBObj{
 
 public:
-	OtherObj(uint32_t initial_value) : RIBObj<uint32_t>(initial_value){};
+	OtherObj(uint32_t initial_value) : RIBObj(){
+		initial_value_ = initial_value;
+	};
 	virtual ~OtherObj(){};
 
 	const std::string& get_class() const{
@@ -369,6 +374,7 @@ public:
 
 	MyObjEncoder encoder;
 	static const std::string class_;
+	uint32_t initial_value_;
 };
 
 const std::string OtherObj::class_ = "OtherObj";
@@ -768,7 +774,7 @@ void ribBasicOps::testAddObj(){
 
 	//Attempt to add them into an invalid RIB handle
 	try{
-		ribd->addObjRIB(wrong_handle, name1, &obj1);
+		ribd->addObjRIB(wrong_handle, name1, obj1);
 		CPPUNIT_ASSERT_MESSAGE("Add obj to with an invalid RIB handle succeeded", 0);
 	}catch(eRIBNotFound& e){
 
@@ -778,7 +784,7 @@ void ribBasicOps::testAddObj(){
 
 	//Attempt to add them into a valid RIB handle but with invalid names
 	try{
-		ribd->addObjRIB(handle, invalid_name1, &obj1);
+		ribd->addObjRIB(handle, invalid_name1, obj1);
 		CPPUNIT_ASSERT_MESSAGE("Add obj to with an invalid name to RIB handle succeeded", 0);
 	}catch(eObjInvalidName& e){
 
@@ -786,7 +792,7 @@ void ribBasicOps::testAddObj(){
 		CPPUNIT_ASSERT_MESSAGE("Invalid exception throw during Add obj with an invalid name to RIB handle", 0);
 	}
 	try{
-		ribd->addObjRIB(handle, invalid_name2, &obj1);
+		ribd->addObjRIB(handle, invalid_name2, obj1);
 		CPPUNIT_ASSERT_MESSAGE("Add obj to with an invalid name to RIB handle succeeded", 0);
 	}catch(eObjInvalidName& e){
 
@@ -794,7 +800,7 @@ void ribBasicOps::testAddObj(){
 		CPPUNIT_ASSERT_MESSAGE("Invalid exception throw during Add obj with an invalid name to RIB handle", 0);
 	}
 	try{
-		ribd->addObjRIB(handle, invalid_name3, &obj1);
+		ribd->addObjRIB(handle, invalid_name3, obj1);
 		CPPUNIT_ASSERT_MESSAGE("Add obj to with an invalid name to RIB handle succeeded", 0);
 	}catch(eObjInvalidName& e){
 
@@ -805,7 +811,7 @@ void ribBasicOps::testAddObj(){
 	//Add the right object (/x)
 	try{
 		tmp = obj1;
-		inst_id1 = ribd->addObjRIB(handle, name1, &obj1);
+		inst_id1 = ribd->addObjRIB(handle, name1, obj1);
 		CPPUNIT_ASSERT_MESSAGE("Did not set to null obj1", obj1 == NULL);
 		CPPUNIT_ASSERT_MESSAGE("Invalid instance id for obj1", inst_id1 == 1);
 		obj1 = tmp;
@@ -833,7 +839,7 @@ void ribBasicOps::testAddObj(){
 
 	tmp = obj2;
 	try{
-		ribd->addObjRIB(handle, name1, &obj2);
+		ribd->addObjRIB(handle, name1, obj2);
 		CPPUNIT_ASSERT_MESSAGE("Add overlapping object to RIB succeeded", 0);
 	}catch(eObjExists& e){
 		CPPUNIT_ASSERT_MESSAGE("Add overlapping object failed, but modified the object pointer",  tmp == obj2);
@@ -844,7 +850,7 @@ void ribBasicOps::testAddObj(){
 	//Add another valid object (/y)
 	try{
 		tmp = obj2;
-		inst_id2 = ribd->addObjRIB(handle, name2, &obj2);
+		inst_id2 = ribd->addObjRIB(handle, name2, obj2);
 		CPPUNIT_ASSERT_MESSAGE("Did not set to null obj2", obj2 == NULL);
 		CPPUNIT_ASSERT_MESSAGE("Invalid instance id for obj2", inst_id2 == 2);
 		obj2 = tmp;
@@ -871,7 +877,7 @@ void ribBasicOps::testAddObj(){
 	//Retry overlap should fail
 	tmp = obj2;
 	try{
-		ribd->addObjRIB(handle, name2, &obj2);
+		ribd->addObjRIB(handle, name2, obj2);
 		CPPUNIT_ASSERT_MESSAGE("Add overlapping object to RIB succeeded", 0);
 	}catch(eObjExists& e){
 		CPPUNIT_ASSERT_MESSAGE("Add overlapping object failed, but modified the object pointer",  tmp == obj2);
@@ -882,7 +888,7 @@ void ribBasicOps::testAddObj(){
 	//Add an inner object (/x/z)
 	try{
 		tmp = obj3;
-		inst_id3 = ribd->addObjRIB(handle, name3, &obj3);
+		inst_id3 = ribd->addObjRIB(handle, name3, obj3);
 		CPPUNIT_ASSERT_MESSAGE("Did not set to null obj3", obj3 == NULL);
 		CPPUNIT_ASSERT_MESSAGE("Invalid instance id for obj3", inst_id3 == 3);
 		obj3 = tmp;
@@ -910,7 +916,7 @@ void ribBasicOps::testAddObj(){
 	//Add an inner object (/x/other)
 	try{
 		OtherObj* tmp2 = obj4;
-		inst_id4 = ribd->addObjRIB(handle, name_other, &obj4);
+		inst_id4 = ribd->addObjRIB(handle, name_other, obj4);
 		CPPUNIT_ASSERT_MESSAGE("Did not set to null obj4", obj4 == NULL);
 		CPPUNIT_ASSERT_MESSAGE("Invalid instance id for obj4", inst_id4 == 4);
 		obj4 = tmp2;
@@ -922,7 +928,7 @@ void ribBasicOps::testAddObj(){
 	//Add an inner object (/x/delegated_subtree)
 	MyDelegationObj* deleg = new MyDelegationObj();
 	try{
-		inst_deleg = ribd->addObjRIB(handle, name_delegated, &deleg);
+		inst_deleg = ribd->addObjRIB(handle, name_delegated, deleg);
 		CPPUNIT_ASSERT_MESSAGE("Invalid instance id for obj4", inst_deleg == 5);
 	}catch(...){
 		CPPUNIT_ASSERT_MESSAGE("Exception thrown during delegate obj", 0);


### PR DESCRIPTION
Removed object value and embedded encoders. Needs to add the renmoved abstractEncoder
+class AbstractEncoder {
+
+public:
-       virtual ~AbstractEncoder(){};
  +};
  +
  +template<class T>
  +class Encoder: public AbstractEncoder {
  +
  +public:
-       virtual ~Encoder(){}
  +
-       /// Converts an object to a byte array, if this object is recognized by the encoder
-       /// @param object
-       /// @throws exception if the object is not recognized by the encoder
-       /// @return
-       virtual void encode(const T &obj, cdap_rib::ser_obj_t& serobj) = 0;
-       /// Converts a byte array to an object of the type specified by "className"
-       /// @param byte[] serializedObject
-       /// @param objectClass The type of object to be decoded
-       /// @throws exception if the byte array is not an encoded in a way that the
-       /// encoder can recognize, or the byte array value doesn't correspond to an
-       /// object of the type "className"
-       /// @return
-       virtual void decode(const cdap_rib::ser_obj_t &serobj,
-                       T& des_obj) = 0;
  +};
  +
